### PR TITLE
Fixes typo in webpack configuration

### DIFF
--- a/web/app/themes/justicejobs/package.json
+++ b/web/app/themes/justicejobs/package.json
@@ -9,7 +9,7 @@
     "main": "index.js",
     "scripts": {
         "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "npm run development -- --watch",
+        "watch": "npm run dev -- --watch",
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },


### PR DESCRIPTION
The 'watch' script was referencing the 'development' script, but this had been renamed to 'dev'. This fixes that, so that the 'watch' script can run.