### PR TITLE
Fix class names on search page

### DIFF
--- a/web/app/themes/justicejobs/search-apply-page.php
+++ b/web/app/themes/justicejobs/search-apply-page.php
@@ -35,7 +35,7 @@ Template Name: Search/Apply Template
 </section>
 
 
-<div class="search">
+<div class="search_contain">
   <div id="allLocations" data-user-location='<?php echo $_location; ?>' data-relevant-terms=''>
     <?php
     $terms = get_terms( array(
@@ -217,10 +217,10 @@ Template Name: Search/Apply Template
       <button class="btn btn--blue" role="button">Search jobs</button>
     </form>
   </div>
-  <div class="search__wrap">
+  <div class="search_contain__wrap">
     <label for="list-view" class="screen-reader-text">Select List View</label>
     <input
-      class="search__radio search__radio--list"
+      class="search_contain__radio search_contain__radio--list"
       name="search"
       type="radio"
       id="list-view"
@@ -229,7 +229,7 @@ Template Name: Search/Apply Template
     />
     <label for="map-view" class="screen-reader-text">Select Map View</label>    
     <input
-      class="search__radio search__radio--map"
+      class="search_contain__radio search_contain__radio--map"
       name="search"
       id="map-view"
       type="radio"
@@ -254,7 +254,7 @@ Template Name: Search/Apply Template
       $pagenum = $job_query->query_vars['paged'] < 1 ? 1 : $job_query->query_vars['paged'];
       $first = ( ( $pagenum - 1 ) * $job_query->query_vars['posts_per_page'] ) + 1;
       $last = $first + $job_query->post_count - 1;
-      echo "<span class='search__results search__results--live'>Showing <b>" . $first . " - " . $last . "</b> of <b>" . "$job_query->found_posts" . "</b> job results</span>";
+      echo "<span class='search_contain__results search_contain__results--live'>Showing <b>" . $first . " - " . $last . "</b> of <b>" . "$job_query->found_posts" . "</b> job results</span>";
        ?>
        <div class="pagination">
          <?php
@@ -274,15 +274,15 @@ Template Name: Search/Apply Template
           ?>
        </div>
 
-      <div class="search__controls">
+      <div class="search_contain__controls">
         <span>VIEW BY</span>
-        <label class="search__label search__label--list" for="list-view">
+        <label class="search_contain__label search_contain__label--list" for="list-view">
           List
           <svg width="28" height="28">
             <use xlink:href="#icon-list"></use>
           </svg>
         </label>
-        <label class="search__label search__label--map" for="map-view">
+        <label class="search_contain__label search_contain__label--map" for="map-view">
           Map
           <svg width="17" height="24">
             <use xlink:href="#icon-marker"></use>
@@ -290,10 +290,10 @@ Template Name: Search/Apply Template
         </label>
       </div>
     </header>
-    <div class="search__container">
-      <div class="search__list-wrap">
-        <table class="search__list">
-          <tr class="search__heading">
+    <div class="search_contain__container">
+      <div class="search_contain__list-wrap">
+        <table class="search_contain__list">
+          <tr class="search_contain__heading">
             <th>ROLE</th>
             <th>LOCATION</th>
             <th>SALARY</th>
@@ -305,7 +305,7 @@ Template Name: Search/Apply Template
     					$job_query->the_post();
           ?>
 
-          <tr class="search__item">
+          <tr class="search_contain__item">
             <td>
               <p><?php the_title(); ?></p>
             </td>
@@ -364,7 +364,7 @@ Template Name: Search/Apply Template
         </table>
       </div>
 
-      <div class="search__map-wrap">
+      <div class="search_contain__map-wrap">
         <div
           class="map"
           id="map"


### PR DESCRIPTION
The class names used were changed but not updated in the search apply template causing the layout to break. This updates the classes.