### PR TITLE
Adds sprite file back in - trello ticket #460

### DIFF
--- a/web/app/themes/justicejobs/webpack.mix.js
+++ b/web/app/themes/justicejobs/webpack.mix.js
@@ -28,8 +28,8 @@ mix.js([
                 require('imagemin-mozjpeg')({
                     quality: 82,
                     progressive: true,
-                }),
-            ],
+                })
+            ]
         }
     )
     .copy('src/img/*.svg', dist + 'img')

--- a/web/app/themes/justicejobs/webpack.mix.js
+++ b/web/app/themes/justicejobs/webpack.mix.js
@@ -28,10 +28,11 @@ mix.js([
                 require('imagemin-mozjpeg')({
                     quality: 82,
                     progressive: true,
-                })
+                }),
             ],
         }
     )
+    .copy('src/img/*.svg', dist + 'img')
     .options({
         processCssUrls: false
     });


### PR DESCRIPTION
This adds a line into webpack that copies the SVG files over to the dist folder after the minification has happened. Something in the minification process was stripping the content out of sprite.svg, which was causing the icons to disappear across the site. 

There is a tool called SVGO which minimises SVG files, but it is a little old and the last build of it failed. The approach in this commit works, and the SVG file is small so optimising it is unlikely to make much of a difference. Open to suggestions, though.