### PR TITLE
Adds aria information to accordion - trello ticket #454

### DIFF
--- a/web/app/themes/justicejobs/page-campaign.php
+++ b/web/app/themes/justicejobs/page-campaign.php
@@ -119,15 +119,23 @@ Template Post Type: page, campaign
       <?php if ( have_rows('accordion') ): while( have_rows('accordion') ): the_row(); ?>
       <div class="accordion__block">
         <div class="campaign--container">
-          <button class="accordion__btn" role="button" aria-label="Open Accordion" aria-expanded="false">
-            <span><?php the_sub_field('accordion_title'); ?></span>
+          <button
+              class="accordion__btn"
+              aria-controls="accordion-<?php the_field( 'accordion_section_title' );?>"
+              aria-expanded="false"
+              id="<?php the_field( 'accordion_section_title' );?>">
+            <h3><?php the_sub_field('accordion_title'); ?></h3>
             <span class="btn-plus">
               <svg width="30" height="30">
                 <use xlink:href="#icon-plus"></use>
               </svg>
             </span>
           </button>
-          <div class="accordion__content-wrap">
+          <div
+              class="accordion__content-wrap"
+              id="accordion-<?php the_field( 'accordion_section_title' );?>"
+              aria-labelledby="<?php the_field( 'accordion_section_title' );?>"
+              role="region">
             <?php the_sub_field('accordion_content'); ?>
 
             <?php

--- a/web/app/themes/justicejobs/page-campaign.php
+++ b/web/app/themes/justicejobs/page-campaign.php
@@ -121,9 +121,9 @@ Template Post Type: page, campaign
         <div class="campaign--container">
           <button
               class="accordion__btn"
-              aria-controls="accordion-<?php the_field( 'accordion_section_title' );?>"
+              aria-controls="accordion-<?php the_sub_field( 'accordion_title' );?>"
               aria-expanded="false"
-              id="<?php the_field( 'accordion_section_title' );?>">
+              id="<?php the_sub_field( 'accordion_title' );?>">
             <h3><?php the_sub_field('accordion_title'); ?></h3>
             <span class="btn-plus">
               <svg width="30" height="30">
@@ -133,8 +133,8 @@ Template Post Type: page, campaign
           </button>
           <div
               class="accordion__content-wrap"
-              id="accordion-<?php the_field( 'accordion_section_title' );?>"
-              aria-labelledby="<?php the_field( 'accordion_section_title' );?>"
+              id="accordion-<?php the_sub_field( 'accordion_title' );?>"
+              aria-labelledby="<?php the_sub_field( 'accordion_title' );?>"
               role="region">
             <?php the_sub_field('accordion_content'); ?>
 
@@ -206,7 +206,11 @@ Template Post Type: page, campaign
               <div class="accordion">
                 <div class="inner_accordion__block">
                   <div class="campaign--container inner_accordion--container">
-                    <button class="inner_accordion__btn" role="button" aria-label="Open Accordion" aria-expanded="false">
+                    <button
+                        class="inner_accordion__btn"
+                        aria-controls="accordion-<?php the_sub_field( 'accordion_title' );?>"
+                        aria-expanded="false"
+                        id="<?php the_sub_field( 'accordion_title' );?>">
                       <span><?php echo $accordion_group['accordion_title']; ?></span>
                       <span class="inner_btn-plus">
                         <svg width="30" height="30">
@@ -214,7 +218,11 @@ Template Post Type: page, campaign
                         </svg>
                       </span>
                     </button>
-                    <div class="inner_accordion__content-wrap">
+                    <div
+                        class="inner_accordion__content-wrap"
+                        id="accordion-<?php the_sub_field( 'accordion_title' );?>"
+                        aria-labelledby="<?php the_sub_field( 'accordion_title' );?>"
+                        role="region">>
                       <?php echo $accordion_group['accordion_content']; ?>
                     </div>
                   </div>

--- a/web/app/themes/justicejobs/page-campaign.php
+++ b/web/app/themes/justicejobs/page-campaign.php
@@ -5,7 +5,7 @@ Template Post Type: page, campaign
 */
 
 ?>
-<?php get_header(); ?>
+<?php get_header(  ); ?>
 
 <section class="hero">
   <div class="hero__img-block">
@@ -116,14 +116,24 @@ Template Post Type: page, campaign
   <div class="campaign__accordion">
     <h2 class="heading--md"><?php the_field( 'accordion_section_title' );?></h2>
     <div class="accordion">
-      <?php if ( have_rows('accordion') ): while( have_rows('accordion') ): the_row(); ?>
+      <?php
+
+
+
+      if ( have_rows('accordion') ): while( have_rows('accordion') ): the_row();
+
+
+      $accordion_title = get_sub_field('accordion_title');
+      $accordion_title = sanitize_title_with_dashes($accordion_title);
+
+      ?>
       <div class="accordion__block">
         <div class="campaign--container">
           <button
               class="accordion__btn"
-              aria-controls="accordion-<?php the_sub_field( 'accordion_title' );?>"
+              aria-controls="accordion-<?= $accordion_title ?>"
               aria-expanded="false"
-              id="<?php the_sub_field( 'accordion_title' );?>">
+              id="jj-<?= $accordion_title ?>">
             <h3><?php the_sub_field('accordion_title'); ?></h3>
             <span class="btn-plus">
               <svg width="30" height="30">
@@ -133,8 +143,8 @@ Template Post Type: page, campaign
           </button>
           <div
               class="accordion__content-wrap"
-              id="accordion-<?php the_sub_field( 'accordion_title' );?>"
-              aria-labelledby="<?php the_sub_field( 'accordion_title' );?>"
+              id="accordion-<?= $accordion_title ?>"
+              aria-labelledby="jj-<?= $accordion_title ?>"
               role="region">
             <?php the_sub_field('accordion_content'); ?>
 
@@ -202,15 +212,17 @@ Template Post Type: page, campaign
               <?php $add_accordion = get_sub_field('add_inner_accordion');
               if ( $add_accordion ):
                 $accordion_group = get_sub_field('inner');
+                $accordion_inner_title = $accordion_group['accordion_title'];
+                $accordion_inner_title = sanitize_title_with_dashes($accordion_inner_title);
               ?>
               <div class="accordion">
                 <div class="inner_accordion__block">
                   <div class="campaign--container inner_accordion--container">
                     <button
                         class="inner_accordion__btn"
-                        aria-controls="accordion-<?php the_sub_field( 'accordion_title' );?>"
+                        aria-controls="accordion-<?= $accordion_inner_title ?>"
                         aria-expanded="false"
-                        id="<?php the_sub_field( 'accordion_title' );?>">
+                        id="jj-<?= $accordion_inner_title ?>">
                       <span><?php echo $accordion_group['accordion_title']; ?></span>
                       <span class="inner_btn-plus">
                         <svg width="30" height="30">
@@ -220,8 +232,8 @@ Template Post Type: page, campaign
                     </button>
                     <div
                         class="inner_accordion__content-wrap"
-                        id="accordion-<?php the_sub_field( 'accordion_title' );?>"
-                        aria-labelledby="<?php the_sub_field( 'accordion_title' );?>"
+                        id="accordion-<?= $accordion_inner_title ?>"
+                        aria-labelledby="jj-<?= $accordion_inner_title ?>"
                         role="region">>
                       <?php echo $accordion_group['accordion_content']; ?>
                     </div>

--- a/web/app/themes/justicejobs/src/js/main.js
+++ b/web/app/themes/justicejobs/src/js/main.js
@@ -152,15 +152,22 @@ jQuery(document).ready(function ($) {
         if (block.hasClass('is-opened')) {
             block
                 .removeClass('is-opened')
+                .attr("aria-expanded", "false")
                 .find('.accordion__content-wrap')
                 .slideUp();
+            $('.accordion__btn')
+                .attr("aria-expanded", "false")
         } else {
             $('.accordion__block')
                 .removeClass('is-opened')
+                .attr("aria-expanded", "false")
                 .find('.accordion__content-wrap')
                 .slideUp();
+            $('.accordion__btn')
+                .attr("aria-expanded", "true")
             block
                 .addClass('is-opened')
+                .attr("aria-expanded", "true")
                 .find('.accordion__content-wrap')
                 .slideDown();
         }
@@ -173,6 +180,7 @@ jQuery(document).ready(function ($) {
         if (block.hasClass('inner_is-opened')) {
             block
                 .removeClass('inner_is-opened')
+                .attr("aria-expanded", "false")
                 .find('.inner_accordion__content-wrap')
                 .slideUp();
         } else {
@@ -182,6 +190,7 @@ jQuery(document).ready(function ($) {
             //   .slideUp();
             block
                 .addClass('inner_is-opened')
+                .attr("aria-expanded", "true")
                 .find('.inner_accordion__content-wrap')
                 .slideDown();
         }

--- a/web/app/themes/justicejobs/src/js/main.js
+++ b/web/app/themes/justicejobs/src/js/main.js
@@ -196,6 +196,41 @@ jQuery(document).ready(function ($) {
         }
     });
 
+    $('.accordion__btn').on('keydown', function () {
+        var target = event.target;
+        var key = event.which.toString();
+
+        // 33 = Page Up, 34 = Page Down
+        var ctrlModifier = (event.ctrlKey && key.match(/33|34/));
+
+        // Collects where current focus is in relation to other accordions
+        var triggers = $('.accordion__btn');
+        var current = triggers.filter(target);
+        var position = triggers.index(current);
+
+        // 38 = Up, 40 = Down
+        if (key.match(/38|40/) || ctrlModifier) {
+            var direction = (key.match(/34|40/)) ? 1 : -1;
+            var length = triggers.length;
+            var newIndex = (position + length + direction) % length;
+            triggers[newIndex].focus();
+            event.preventDefault();
+        }
+        else if (key.match(/35|36/)) {
+            // 35 = End, 36 = Home keyboard operations
+            switch (key) {
+                case '36':
+                    triggers[0].focus();
+                    break;
+                case '35':
+                    triggers[triggers.length - 1].focus();
+                    break;
+            }
+            event.preventDefault();
+        }
+    });
+
+
     if ($('.campaign__carousel').length > 0) {
         $('.campaign__carousel').slick({
             dots: true,


### PR DESCRIPTION
Each accordion previously was announced as 'open accordion'. They now announce the content that's the accordion title, and the screen reader user is informed when they expand and collapse. It's been tested with VoiceOver in Safari. 

Still a couple of things left to do before it's finished:

- [x] tidy up the IDs
- [ ] figure out a solution for the content coming in from the admin panel (heading levels)