### PR TITLE
Fix bug with keyboard search submit - ticket #475

### DIFF
--- a/web/app/themes/justicejobs/search-apply-page.php
+++ b/web/app/themes/justicejobs/search-apply-page.php
@@ -215,7 +215,7 @@ Template Name: Search/Apply Template
             ?>
           </ul>
         </div>
-        <button class="btn btn--blue" role="button">Search jobs</button>
+        <button class="btn btn--blue" role="button" type="submit">Search jobs</button>
         </fieldset>
     </form>
   </div>

--- a/web/app/themes/justicejobs/search.php
+++ b/web/app/themes/justicejobs/search.php
@@ -237,7 +237,7 @@ $_locations_relevant_array_pop = array_pop($_locations_relevant_array);
                     ?>
                 </ul>
             </div>
-            <button class="btn btn--blue" role="button">Search jobs</button>
+            <button class="btn btn--blue" role="button" type="submit">Search jobs</button>
             </fieldset>
         </form>
     </div>


### PR DESCRIPTION
There was an issue where the form on the search page was clearing and not filtering when you pressed enter on the keyboard to submit it. This adds in type="submit", which fixes it.