### PR TITLE
Fix map not loading as first view when page is loaded for first time

### DIFF
--- a/web/app/themes/justicejobs/search-apply-page.php
+++ b/web/app/themes/justicejobs/search-apply-page.php
@@ -219,7 +219,7 @@ Template Name: Search/Apply Template
         </fieldset>
     </form>
   </div>
-  <div class="search_contain__wrap">
+  <div class="search_contain__wrap" id="jj-search-results-view">
 
     <header>
 
@@ -276,7 +276,7 @@ Template Name: Search/Apply Template
         </div>
 
     </header>
-    <div class="search_contain__container" id="js-show-map jj-search-results-view" role="region" aria-live="polite">
+    <div class="search_contain__container" id="js-show-map" role="region" aria-live="polite">
       <div class="search_contain__list-wrap" >
         <table class="search_contain__list">
           <caption class="screen-reader-text">Job search results</caption>

--- a/web/app/themes/justicejobs/search.php
+++ b/web/app/themes/justicejobs/search.php
@@ -240,7 +240,7 @@ $_locations_relevant_array_pop = array_pop($_locations_relevant_array);
             </fieldset>
         </form>
     </div>
-    <div class="search_contain__wrap">
+    <div class="search_contain__wrap" id="jj-search-results-view">
 
         <header>
             <?php
@@ -589,7 +589,7 @@ $_locations_relevant_array_pop = array_pop($_locations_relevant_array);
             </div>
         </header>
 
-        <div class="search_contain__container" id="js-show-map jj-search-results-view" role="region" aria-live="polite">
+        <div class="search_contain__container" id="js-show-map" role="region" aria-live="polite">
             <div class="search_contain__list-wrap" >
                 <table class="search_contain__list">
                     <caption class="screen-reader-text">Job search results</caption>


### PR DESCRIPTION
The initial multiple IDs was causing issues. The 'jj-search-results-view' was also being overwritten by the jQuery. This moves it to prevent this from happening.

This should also help the ARIA work. There is still an issue in that switching back to the map view isn't read out by screen readers via `aria-live="polite"` - this might be user error though, so is something to check for in the retest.