### PR TITLE
Job text column

### DIFF
--- a/web/app/themes/justicejobs/src/scss/layout/_job.scss
+++ b/web/app/themes/justicejobs/src/scss/layout/_job.scss
@@ -1,6 +1,6 @@
 .job {
     margin-bottom: 100px;
-    width: 100rem;
+    max-width: 100rem;
     &__wrap {
         padding: 40px 15px;
         @include respond-to(md) {

--- a/web/app/themes/justicejobs/src/scss/layout/_job.scss
+++ b/web/app/themes/justicejobs/src/scss/layout/_job.scss
@@ -1,7 +1,6 @@
 .job {
     margin-bottom: 100px;
-    display: flex;
-    flex-direction: column;
+    width: 100rem;
     &__wrap {
         padding: 40px 15px;
         @include respond-to(md) {
@@ -15,16 +14,9 @@
         }
     }
     &__text-wrap {
-        @include respond-to(sm) {
-            column-count: 2;
-            column-gap: 60px;
-        }
         header,
         footer {
             margin-bottom: 30px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
             @include respond-to(md) {
                 margin-bottom: 60px;
             }
@@ -32,8 +24,6 @@
         footer {
             margin-bottom: 0;
             @include respond-to(md) {
-                flex-direction: column;
-                align-items: flex-start;
                 .btn {
                     margin-bottom: 30px;
                 }


### PR DESCRIPTION
This removes the flex column layout, so that it is now a single column. I've made it 100rem wide, because ~80rem is the ideal line length for reading. Anything longer tends to make text hard to read. 