### PR TITLE
Removes inline width and tidies up ARIA

### DIFF
--- a/web/app/themes/justicejobs/header.php
+++ b/web/app/themes/justicejobs/header.php
@@ -20,11 +20,8 @@
     <a href="<?php bloginfo('url'); ?>" aria-label="Back to Home" class="page-header__logo">
         <span class="screen-reader-text">Back to Home</span>
         <img
-            width="188"
-            height="28"
             src="<?php echo esc_url(get_template_directory_uri()); ?>/dist/img/logo--white.svg"
-            alt="Ministry of Justice Logo - this takes the user back to the homepage"
-            aria-hidden="true"
+            alt="Ministry of Justice Logo - homepage"
         />
     </a>
     <button class="page-header__menu closed">


### PR DESCRIPTION
I suspect that specifiying the height and width on the `<img>` tag is what is causing the IE bug where Justice Jobs is slightly cut off. Given these very closely match the actual image size, I've removed them, so we can test that it fixes it in IE. 

I've also tidied up the ARIA information, as it was a little confusing.