### PR TITLE
Fix Vertical white space on agency blocks

### DIFF
--- a/web/app/themes/justicejobs/src/scss/layout/_agency.scss
+++ b/web/app/themes/justicejobs/src/scss/layout/_agency.scss
@@ -16,14 +16,14 @@
             display: flex;
             flex-direction: column;
 
-            @include respond-to(md) {
+            @include respond-to(lg) {
                 flex-direction: row;
                 flex-wrap: wrap;
                 align-items: flex-start;
             }
 
             .btn-big {
-                @include respond-to(md) {
+                @include respond-to(lg) {
                     margin-top: 80px;
                 }
             }


### PR DESCRIPTION
The issue wasnt stray tags it was actually the styling being at the wrong breakpoint. So now the agency blocks are not oddly spaced on tablet/small desktop