### PR TITLE
Fix Job titles in IE. Also remove IE specific stylesheet.

### DIFF
--- a/web/app/themes/justicejobs/functions.php
+++ b/web/app/themes/justicejobs/functions.php
@@ -86,9 +86,6 @@ function enqueue_justice_jobs_scripts()
     // CSS
     wp_enqueue_style('core-css', mix_asset('/css/main.min.css'), array(), null, 'all');
 
-    wp_enqueue_style('ie-css', mix_asset('/css/ie.min.css'), array(), null, 'all');
-    wp_style_add_data('ie-css', 'conditional', 'IE');
-
     // JS and jQuery
     wp_enqueue_script('core-js', mix_asset('/js/main.min.js'), array('jquery'), null, true);
 

--- a/web/app/themes/justicejobs/src/scss/ie.scss
+++ b/web/app/themes/justicejobs/src/scss/ie.scss
@@ -1,1 +1,13 @@
 /** IE Specific Styles */
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .search_contain {
+
+    &__container#js-show-map {
+      .search_contain__item {
+        display: block;
+      }
+    }
+
+  }
+}

--- a/web/app/themes/justicejobs/src/scss/style.scss
+++ b/web/app/themes/justicejobs/src/scss/style.scss
@@ -16,3 +16,5 @@
 @import 'pages/home';
 
 @import 'themes/default';
+
+@import 'ie';

--- a/web/app/themes/justicejobs/webpack.mix.js
+++ b/web/app/themes/justicejobs/webpack.mix.js
@@ -13,7 +13,6 @@ mix.js([
     ], dist + 'js/main.min.js')
     .js('src/js/jj-gtm.js', dist + 'js/jj-gtm.min.js')
     .sass('src/scss/style.scss', dist + 'css/main.min.css')
-    .sass('src/scss/ie.scss', dist + 'css/ie.min.css')
     .sass('src/scss/errors/404.sass', dist + 'css/404.css')
     .sass('src/scss/errors/error-page.sass', dist + 'css/error-page.css')
     .copy('src/video/*', dist + 'video')


### PR DESCRIPTION
Removed the IE specific stylesheet as conditional stylesheets are not supported in IE10+. Fixed the job title length issue.