### PR TITLE
Update README to reflect site name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Template WordPress project
+# Justice Jobs site
 
 Use this template to bootstrap a new WordPress project for use in the MOJ docker hosting environment.
 


### PR DESCRIPTION
Update README to site name so it doesn't use the cut and paste Wordpress template name.