### PR TITLE
Restrict Campaign Template

### DIFF
--- a/web/app/themes/justicejobs/single-campaign.php
+++ b/web/app/themes/justicejobs/single-campaign.php
@@ -1,7 +1,6 @@
 <?php
 /*
 Template Name: Campaign Template
-Template Post Type: page, campaign
 */
 
 ?>


### PR DESCRIPTION
The Campaign Template was being used on Pages. These should be created in the campaign cpt. I have converted template to single-capaign so it is the default template used by campaign cpt.