### PR TITLE
Move about page carousel button down and add solid background to text

### DIFF
--- a/web/app/themes/justicejobs/src/scss/components/_carousel.scss
+++ b/web/app/themes/justicejobs/src/scss/components/_carousel.scss
@@ -7,9 +7,7 @@
     height: 100%;
     background-color: $even-darker-blue;
 
-
     .work__text-block {
-
         .accessible-carousel--full-width & {
             .quote-copy {
                 font-size: 2.0rem;
@@ -20,7 +18,6 @@
             }
         }
     }
-
 
     &--full-width {
         @include respond-to(md) {
@@ -99,7 +96,6 @@
         }
 
         .accessible-carousel--full-width & {
-
             width: 100%;
 
             align-items: flex-start;
@@ -168,8 +164,10 @@
             position: absolute;
             bottom: 88px;
 
+
             &.about {
                 background-color: inherit;
+                bottom: 30px;
             }
 
             &:focus {
@@ -276,6 +274,13 @@
 
     .heading--sm {
         margin-bottom: 15px;
+    }
+
+    .text-highlight {
+        box-shadow: -17px 3px 0 3px $dark-grey, 17px 3px 0 3px $dark-grey;
+        background-color: $dark-grey;
+        -webkit-box-decoration-break: clone;
+        box-decoration-break: clone;
     }
 
     .btn-secondary {


### PR DESCRIPTION
The text in the about page carousel needed to have a solid background colour. In order to see the text in the carousel though, the 'find out more' button needed moving down too.

This completes ticket #672 and addresses ticket #747