### PR TITLE
Update carousel button order and text from slide to item

### DIFF
--- a/web/app/themes/justicejobs/front-page.php
+++ b/web/app/themes/justicejobs/front-page.php
@@ -82,9 +82,7 @@
         <div class="hero__carousel">
             <div class="accessible-carousel" id="accessible-carousel">
                 <?php if (have_rows('latest_roles_carousel')) : ?>
-                    <div class="accessible-carousel__controls">
 
-                    </div>
                     <ul class="accessible-carousel__container">
                         <?php while (have_rows('latest_roles_carousel')) :
                             the_row();
@@ -108,6 +106,8 @@
                             </li>
                         <?php endwhile; ?>
                     </ul>
+
+                    <div class="accessible-carousel__controls"></div>
                 <?php endif; ?>
             </div>
         </div>

--- a/web/app/themes/justicejobs/page-about.php
+++ b/web/app/themes/justicejobs/page-about.php
@@ -83,9 +83,7 @@ get_header();
             <div id="accessible-carousel">
 
                 <?php $agencies = get_field('featured_agencies'); ?>
-                <div class="accessible-carousel__controls">
 
-                </div>
                 <ul class="accessible-carousel__container">
                     <?php foreach ($agencies as $agency) :
                         $agency_image = get_field('agency_hero_desktop_image', $agency->ID);
@@ -143,6 +141,8 @@ get_header();
 
                     <?php endforeach; ?>
                 </ul>
+
+                <div class="accessible-carousel__controls"></div>
             </div>
         </div>
 

--- a/web/app/themes/justicejobs/single-agency.php
+++ b/web/app/themes/justicejobs/single-agency.php
@@ -76,9 +76,6 @@ Template Post Type: agency
 
                         <?php if (have_rows('carousel')) : ?>
                             <div id="accessible-full-carousel">
-                                <div class="accessible-carousel__controls">
-
-                                </div>
                                 <ul class="accessible-carousel__container">
                                     <?php while (have_rows('carousel')) :
                                         the_row();
@@ -109,6 +106,7 @@ Template Post Type: agency
                                         </li>
                                     <?php endwhile; ?>
                                 </ul>
+                                <div class="accessible-carousel__controls"></div>
                             </div>
                         <?php endif; ?>
                     </div>

--- a/web/app/themes/justicejobs/src/js/accessible-carousel.js
+++ b/web/app/themes/justicejobs/src/js/accessible-carousel.js
@@ -120,8 +120,8 @@ jQuery(document).ready(function ($) {
                     forEachElement(slides, function (el, i) {
                         var li = document.createElement('li');
                         var klass = (i === 0) ? 'class="slide-nav__button--current" ' : '';
-                        var kurrent = (i === 0) ? ' <span class="visually-hidden">(Current slide)</span>' : '';
-                        li.innerHTML = '<button ' + klass + 'data-slide="' + i + '"><span class="visually-hidden">' + (i !== 0 ? 'View ' : 'Viewing ') + 'slide</span> ' + (i + 1) + kurrent + '</button>';
+                        var kurrent = (i === 0) ? ' <span class="visually-hidden">(Current item)</span>' : '';
+                        li.innerHTML = '<button ' + klass + 'data-slide="' + i + '"><span class="visually-hidden">' + (i !== 0 ? 'View ' : 'Viewing ') + 'item</span> ' + (i + 1) + kurrent + '</button>';
                         slidenav.appendChild(li);
                     });
                 }
@@ -220,10 +220,10 @@ jQuery(document).ready(function ($) {
                 var buttons = carousel.querySelectorAll('.slidenav button[data-slide]');
                 for (var j = buttons.length - 1; j >= 0; j--) {
                     buttons[j].className = '';
-                    buttons[j].innerHTML = '<span class="visually-hidden">View slide </span> ' + (j + 1);
+                    buttons[j].innerHTML = '<span class="visually-hidden">View item </span> ' + (j + 1) + '<span class="visually-hidden"> of '+ slides.length + '</span>';
                 }
                 buttons[new_current].className = 'current';
-                buttons[new_current].innerHTML = '<span class="visually-hidden">Viewing slide </span> ' + (new_current + 1) + ' <span class="visually-hidden">(Current slide)</span>';
+                buttons[new_current].innerHTML = '<span class="visually-hidden">Viewing item </span> ' + (new_current + 1) + ' <span class="visually-hidden">of ' + slides.length + ' (Current item)</span>';
             }
 
             // Set the global index to the new current value


### PR DESCRIPTION
The carousel markup order meant that the buttons came before the content, which could be confusing for users of assistive technology. Some of the labels weren't quite clear enough, too. This PR:

- [x] Ajusts the markup order so the carousel item contents comes before the buttons
- [x] Changes wording from 'slide' to 'item' based on a conversation with Josh

When testing, you might hear that it reads out "bullet" before the next/previous buttons. As they are part of a list, [reading out bullet is normal behaviour](https://www.scottohara.me/blog/2018/05/26/aria-lists.html#native-ul-and-ol-announcements). The slides themselves are in a list, but this isn't announced - this is because default styling has been removed, which means that [VoiceOver will not announce they are a list](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html). 

However, if we do the suggested fix and add in `role="list"` it will just read out that the list only contains 1 item. Part of the way the carousel works is by hiding the other carousel items from AT until they've been shuffled to the 'current' view, so that wouldn't be a trivial change.

Given the fact that it is a list is inferred by the buttons, I think this solution is the best for now. I will ask DAC if they can have a quick look to see what they think too once it's on live.

This addresses Trello ticket #673.