### PR TITLE
Add DockerHub auth and update composer

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,7 +1,7 @@
 version: 0.1
 environment_variables:
   plaintext:
-    APPNAME: "design102"
+    APPNAME: "justicejobs"
 phases:
   pre_build:
     commands:
@@ -13,6 +13,8 @@ phases:
       - echo -n -`date "+%Y%m%d%H%M"` >> BUILD_TAG.txt
       - echo Created build tag `cat BUILD_TAG.txt`
       - echo Build started on `date`
+      - echo Docker authenticate
+      - docker login --username "$DOCKERUSERNAME" --password "$DOCKERPASSWORD"
       - echo Building the Docker image...
       - docker build --build-arg COMPOSER_USER="$COMPOSER_USER" --build-arg COMPOSER_PASS="$COMPOSER_PASS" -t $APPNAME:`cat BUILD_TAG.txt` .
       - docker tag $APPNAME:`cat BUILD_TAG.txt` 613903586696.dkr.ecr.eu-west-2.amazonaws.com/wp/$APPNAME:`cat BUILD_TAG.txt`


### PR DESCRIPTION
Access to DockerHub was previously done anonymously causing us to reach
Docker's 100 pull limit. This change uses the MoJ account providing for
unlimited pulls.

Also updated composer so the site is up to date.