### PR TITLE
"Where we work" responsive design

### DIFF
--- a/web/app/themes/justicejobs/src/scss/base/_typography.scss
+++ b/web/app/themes/justicejobs/src/scss/base/_typography.scss
@@ -34,10 +34,13 @@ button {
     font-size: 2.6rem;
     font-weight: 700;
     letter-spacing: 0.31px;
-    line-height: 1.2;
+    line-height: 1.32;
     color: #000;
 
     @include respond-to(sm) {
+        font-size: 2.8rem;
+    }
+    @include respond-to(md) {
         font-size: 3.6rem;
     }
 }


### PR DESCRIPTION
- Changed the line height so descenders are not clipped by the text background of the following line.  
- Added in a new break point to partially reduce text size so three-line titles do not overlap the button at widths of 768px to 1024px (sm to md).  