### PR TITLE
Backup PR to fix salary ranges if needed

### DIFF
--- a/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
+++ b/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
@@ -192,8 +192,6 @@ function set_job_details($job_content, $totalspans, $post_id)
         if ($job_content->div->span[$y]->attributes()->itemprop[0] == "Salary Range") {
             $salary = (string)$job_content->div->span[$y];
             wp_set_object_terms($post_id, $salary, 'salary_range');
-            update_field('salary', htmlspecialchars($salary), $post_id);
-
         }
 
         // Save Salary Min and Max

--- a/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
+++ b/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
@@ -201,12 +201,12 @@ function set_job_details($job_content, $totalspans, $post_id)
             $salary = (string)$job_content->div->span[$y];
             update_field('salary', htmlspecialchars($salary), $post_id);
 
-            $salary = preg_replace("-", " ", $salary); // replace dash with space
+            $salary = str_replace("-", " ", $salary); // replace dash with space
             $salary_range_array = explode(' ', $salary); //split by space, thereby catching all text but no numbers (assuming numbers don't have internal spaces)
             $salary_range_array = preg_replace("/[^0-9]/", "", $salary_range_array); //strip all non-numerics
 
             for ($i=0; $i<=count($salary_range_array);$i++) { //loop through array removing elements less than 5 characters long
-                if (strlen($salary_range_array[$i])<5) unset($salary_range_array[$i]);
+                if (isset($salary_range_array[$i]) && strlen($salary_range_array[$i])<5) unset($salary_range_array[$i]);
             }
 
             $salary_min = min($salary_range_array);

--- a/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
+++ b/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
@@ -199,17 +199,18 @@ function set_job_details($job_content, $totalspans, $post_id)
         if ($job_content->div->span[$y]->attributes()->itemprop[0] == "Salary Minimum") {
             $salary = (string)$job_content->div->span[$y];
 
-            $salary_range_array = explode('-', $salary);
+            $salary = preg_replace("-", " ", $salary); // replace dash with space
+            $salary_range_array = explode(' ', $salary); //split by space, thereby catching all text but no numbers (assuming numbers don't have internal spaces)
+            $salary_range_array = preg_replace("/[^0-9]/", "", $salary_range_array); //strip all non-numerics
 
-            $salary_min = '';
-            $salary_max = '';
-
-            if (count($salary_range_array) > 1) {
-                $salary_min = preg_replace("/[^0-9]/", "", $salary_range_array[0]);
-                $salary_max = preg_replace("/[^0-9]/", "", $salary_range_array[1]);
-            } else {
-                $salary_min = preg_replace("/[^0-9]/", "", $salary_range_array[0]);
+            for ($i=0; $i<=count($salary_range_array);$i++) { //loop through array removing elements less than 5 characters long
+                if (strlen($salary_range_array[$i])<5) unset($salary_range_array[$i]);
             }
+
+            $salary_min = min($salary_range_array);
+            $salary_max = max($salary_range_array);
+
+            if ($salary_max == $salary_min) $salary_max = "";
 
             if (is_numeric($salary_min)) {
                 update_field('salary_min', $salary_min, $post_id);

--- a/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
+++ b/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
@@ -192,12 +192,14 @@ function set_job_details($job_content, $totalspans, $post_id)
         if ($job_content->div->span[$y]->attributes()->itemprop[0] == "Salary Range") {
             $salary = (string)$job_content->div->span[$y];
             wp_set_object_terms($post_id, $salary, 'salary_range');
+            update_field('salary', htmlspecialchars($salary), $post_id);
 
         }
 
         // Save Salary Min and Max
         if ($job_content->div->span[$y]->attributes()->itemprop[0] == "Salary Minimum") {
             $salary = (string)$job_content->div->span[$y];
+            update_field('salary', htmlspecialchars($salary), $post_id);
 
             $salary = preg_replace("-", " ", $salary); // replace dash with space
             $salary_range_array = explode(' ', $salary); //split by space, thereby catching all text but no numbers (assuming numbers don't have internal spaces)

--- a/web/app/themes/justicejobs/single-job.php
+++ b/web/app/themes/justicejobs/single-job.php
@@ -90,6 +90,17 @@
                     the_content();
                     ?>
                     <h2>Additional Information</h2>
+                    <?php
+                    $salary = get_field(('salary'));
+                    if (!empty($salary)) {
+                    ?>
+                        <h3>Salary</h3>
+                        <p>
+                            <span style="font-size: medium;">
+                                <?php echo $salary; ?>
+                            </span>
+                        </p>
+                    <?php } ?>
                     <?php the_field('additional_information'); ?>
 
                 </div>

--- a/web/app/themes/justicejobs/single-job.php
+++ b/web/app/themes/justicejobs/single-job.php
@@ -57,13 +57,13 @@
                 $salary_min = get_field(('salary_min'));
 
                 if(!empty($salary_min)){
-                    echo '&#163;' . number_format($salary_min);
+                    echo '&pound;' . number_format($salary_min);
 
                     $salary_max = get_field(('salary_max'));
 
                     if(!empty($salary_max)){
 
-                        echo ' - &#163;' . number_format($salary_max);
+                        echo ' &ndash; &pound;' . number_format($salary_max);
 
                     }
 


### PR DESCRIPTION
Amended code to retrieve salary range from more erratic entries.
- replaces hyphens with spaces.
- splits by space instead of hyphen, so it creates a very long array. 
- removes all non-numeric characters in the whole array.
- loops through array, removing all array entries that are less than 5 characters in length.
- takes the smallest number as the minimum. 
- takes the largest number as a maximum.
- sets the maximum to nothing if it is equal to the minimum.

Saved the original salary text entry so no data is lost.
Adds a new section "Salary" under "Additional Information" where the original salary text input is displayed.