### PR TITLE
HM Prison Service and HM Probation Service special cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,10 @@
 {
-  "lockfileVersion": 1
+  "name": "wp-justicejobs",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wp-justicejobs"
+    }
+  }
 }

--- a/web/app/themes/justicejobs/front-page.php
+++ b/web/app/themes/justicejobs/front-page.php
@@ -139,7 +139,7 @@
         foreach ($agencies as $agency) :
 
             $featured_img_url = get_field('agency_hero_desktop_image', $agency->ID);
-            $agency_name = $agency->title;
+            $agency_name = $agency->post_title;
             $agency_colour = get_field('agency_colour', $agency->ID);
             $more_link_text = get_field('homepage_link_text', $agency->ID);
             $agency_logo = get_field('agency_logo_white', $agency->ID);

--- a/web/app/themes/justicejobs/single-agency.php
+++ b/web/app/themes/justicejobs/single-agency.php
@@ -62,18 +62,20 @@ Template Post Type: agency
 
                         if (in_array(strip_tags(get_the_title()), $HMPPS_underlings)) {
                             $HMPPS_found = false;
-                            for ($id_search = 0; $id_search<=1000; $id_search++) {
-                                if (preg_match('/HM Prison .* Probation Service/', get_the_title($id_search))) {
+
+                            for ($parent_id_search = 0; $parent_id_search<=1000; $parent_id_search++) {
+                                if (preg_match('/HM Prison .* Probation Service/', get_the_title($parent_id_search))) {
                                     //If we are in either of the underlings, we go through all pages to find the parent agency (HMPPS) ID
                                     $HMPPS_found = true;
                                     break;
                                 }
                             }
+
                             if ($HMPPS_found) {
                                 $parent_agency = array(
                                     "name" => "HMPPS",
-                                    "link" => get_post_permalink($id_search),
-                                    "colour" => get_field('agency_colour',$id_search)
+                                    "link" => get_post_permalink($parent_id_search),
+                                    "colour" => get_field('agency_colour',$parent_id_search)
                                 );
                             }
                         }

--- a/web/app/themes/justicejobs/single-agency.php
+++ b/web/app/themes/justicejobs/single-agency.php
@@ -59,19 +59,23 @@ Template Post Type: agency
                         //Hard coding in HMPPS subordinate agencies to mimic heirarchy
 
                         $HMPPS_underlings = ["HM Prison Service","HM Probation Service"];
-                        $HMPPS_found = false;
-                        for ($id_search = 0; $id_search<=1000; $id_search++) {
-                            if (preg_match('/HM Prison .* Probation Service/', get_the_title($id_search))) {
-                                $HMPPS_found = true;
-                                break;
+
+                        if (in_array(strip_tags(get_the_title()), $HMPPS_underlings)) {
+                            $HMPPS_found = false;
+                            for ($id_search = 0; $id_search<=1000; $id_search++) {
+                                if (preg_match('/HM Prison .* Probation Service/', get_the_title($id_search))) {
+                                    //If we are in either of the underlings, we go through all pages to find the parent agency (HMPPS) ID
+                                    $HMPPS_found = true;
+                                    break;
+                                }
                             }
-                        }
-                        if ($HMPPS_found && in_array(strip_tags(get_the_title()), $HMPPS_underlings)) {
-                            $parent_agency = array(
-                                "name" => "HMPPS",
-                                "link" => get_post_permalink($id_search),
-                                "colour" => get_field('agency_colour',$id_search)
-                            );
+                            if ($HMPPS_found) {
+                                $parent_agency = array(
+                                    "name" => "HMPPS",
+                                    "link" => get_post_permalink($id_search),
+                                    "colour" => get_field('agency_colour',$id_search)
+                                );
+                            }
                         }
                     ?>
                     <a href="<?php echo get_bloginfo('url'); ?>#work" class="btn-back btn-back--agency">

--- a/web/app/themes/justicejobs/single-agency.php
+++ b/web/app/themes/justicejobs/single-agency.php
@@ -55,12 +55,42 @@ Template Post Type: agency
         <div class="agency">
             <div class="agency__col">
                 <div class="agency__text">
+                    <?php
+                        $HMPPS_underlings = ["HM Prison Service","HM Probation Service"];
+                        $HMPPS_found = false;
+                        for ($id_search = 0; $id_search<=1000; $id_search++) {
+                            if (preg_match('/HM Prison .* Probation Service/', get_the_title($id_search))) {
+                                $HMPPS_found = true;
+                                break;
+                            }
+                        }
+                        if ($HMPPS_found && in_array(strip_tags(get_the_title()), $HMPPS_underlings)) {
+                            $parent_agency = array(
+                                "name" => "HMPPS",
+                                "link" => get_post_permalink($id_search),
+                            );
+                        }
+                    ?>
                     <a href="<?php echo get_bloginfo('url'); ?>#work" class="btn-back btn-back--agency">
                         <svg width="8" height="13">
                             <use xlink:href="#icon-arrow"></use>
                         </svg>
-                        Back to Agencies
+                        <?php
+                            if (isset($parent_agency)) {
+                                echo "All agencies";
+                            } else {
+                                echo "Back to Agencies";
+                            }
+                        ?>
                     </a>
+                    <?php if (isset($parent_agency)) { ?>
+                    <a href="<?php echo $parent_agency["link"]; ?>" class="btn-back btn-back--agency">
+                        <svg width="8" height="13">
+                            <use xlink:href="#icon-arrow"></use>
+                        </svg>
+                        <?php echo $parent_agency["name"]; ?>
+                    </a>
+                    <?php } ?>
                     <?php the_field('agency_content'); ?>
                 </div>
             </div>

--- a/web/app/themes/justicejobs/single-agency.php
+++ b/web/app/themes/justicejobs/single-agency.php
@@ -78,9 +78,7 @@ Template Post Type: agency
                         <svg width="8" height="13">
                             <use xlink:href="#icon-arrow"></use>
                         </svg>
-                        <?php
-                            echo "Home";
-                        ?>
+                        Home
                     </a>
                     <?php if (isset($parent_agency)) { ?>
                     <a href="<?php echo $parent_agency["link"]; ?>" class="btn-back btn-back--agency">

--- a/web/app/themes/justicejobs/single-agency.php
+++ b/web/app/themes/justicejobs/single-agency.php
@@ -56,6 +56,8 @@ Template Post Type: agency
             <div class="agency__col">
                 <div class="agency__text">
                     <?php
+                        //Hard coding in HMPPS subordinate agencies to mimic heirarchy
+
                         $HMPPS_underlings = ["HM Prison Service","HM Probation Service"];
                         $HMPPS_found = false;
                         for ($id_search = 0; $id_search<=1000; $id_search++) {
@@ -68,6 +70,7 @@ Template Post Type: agency
                             $parent_agency = array(
                                 "name" => "HMPPS",
                                 "link" => get_post_permalink($id_search),
+                                "colour" => get_field('agency_colour',$id_search)
                             );
                         }
                     ?>
@@ -76,11 +79,7 @@ Template Post Type: agency
                             <use xlink:href="#icon-arrow"></use>
                         </svg>
                         <?php
-                            if (isset($parent_agency)) {
-                                echo "All agencies";
-                            } else {
-                                echo "Back to Agencies";
-                            }
+                            echo "Home";
                         ?>
                     </a>
                     <?php if (isset($parent_agency)) { ?>
@@ -156,6 +155,10 @@ Template Post Type: agency
                         $title_bottom = $bottom_block['title'];
                         $ispopup = get_sub_field('pop_up_block');
                         $bg_colour = 'background-color: ' . get_field('agency_colour');
+                        if (!get_field('agency_colour') && isset($parent_agency)) {
+                            //No agency colour and a parent agency identified
+                            $bg_colour = 'background-color: ' . $parent_agency["colour"];
+                        }
 
                         if ($ispopup) {
 
@@ -185,7 +188,7 @@ Template Post Type: agency
                             role="link"
                         >
                             <span class="heading--xs"><?= $block_title; ?></span>
-                            <h3><?= $title_bottom; ?></h3>
+                            <h3 <?php if (strlen($title_bottom) > 50) echo "class='overly-long-text'"; ?>><?= $title_bottom; ?></h3>
 
                             <a href="<?= esc_url($more_link_bottom['url']); ?>"
                                 target="<?php if (isset($more_link_bottom['target'])) {

--- a/web/app/themes/justicejobs/src/scss/components/_button.scss
+++ b/web/app/themes/justicejobs/src/scss/components/_button.scss
@@ -233,9 +233,9 @@
     }
 
     &--agency {
-        position: absolute;
-        top: 40px;
-        left: 15px;
+        position: relative;
+        top: -40px;
+        left: -15px;
     }
 }
 

--- a/web/app/themes/justicejobs/src/scss/components/_button.scss
+++ b/web/app/themes/justicejobs/src/scss/components/_button.scss
@@ -127,7 +127,7 @@
     @include transition(opacity);
 
     svg {
-        margin-left: 15px;
+        margin-left: 11px;
         height: 15px;
         width: 10px;
         fill: #000;

--- a/web/app/themes/justicejobs/src/scss/layout/_agency.scss
+++ b/web/app/themes/justicejobs/src/scss/layout/_agency.scss
@@ -207,19 +207,22 @@
             font-weight: 700;
             line-height: 1.25;
             width: 60%;
+
+            &.overly-long-text {
+                font-size: 1.8rem;
+            }
         }
 
         h3,
         span,
         a {
-            z-index: 1;
-           padding: 2rem;
-           margin-right: 2rem;
+           z-index: 1;
+           padding: 2rem 1rem;
+           display: inline-block;
             &:focus {
               background: #fecf43;
               color: #000;
               outline: 1px solid black;
-              display: inline-block;
               opacity: 1;
 
               svg {


### PR DESCRIPTION
- Hard coded an array marking these two "agencies" as being subordinate to HMPPS.  
- Hard coded a new attribute for these two "agencies" - parent_agency.
- Added link to parent agency if the attribute is set.
- Renamed the common link to home page "Home" (for all).
- Fixed bug where these faux agencies didn't have an agency colour - use the parent agency colour.
- Fixed bug where screen readers weren't being told where links were going on the homepage.
- Fixed bug with long title text pushing content outside the box (carousel).
- Amended styles to allow for longer secondary buttons.