### PR TITLE
London weighting parsing

### DIFF
--- a/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
+++ b/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
@@ -225,14 +225,15 @@ function set_job_details($job_content, $totalspans, $post_id)
             if (is_numeric($salary_max)) {
                 update_field('salary_max', $salary_max, $post_id);
             }
-            if (preg_match("plus a London weighting allowance of", $salary)) { //London weighting string identified
-                $london_weighting_allowance = explode("plus a London weighting allowance of ", $salary)[1]; //split by start of the agreed term - take second element
+            if (preg_match("/London .* allowance of \£.* per annum/", $salary)) { //London weighting string identified
+                $london_weighting_allowance = preg_replace("/London .* allowance of \£/","|||",$salary); //replace the regex string with a constant for splitting
+                $london_weighting_allowance = explode("|||", $london_weighting_allowance)[1]; //split by start of the agreed term - take second element
                 $london_weighting_allowance = explode(" per annum", $london_weighting_allowance)[0]; //split by end of the agreed term - take first element
                 $london_weighting_allowance = str_replace(".00", "", $london_weighting_allowance); //strip occasional use of .00 (e.g. £3,889.00)
-                $london_weighting_allowance = preg_replace("/[^0-9]/", "", $london_array[1]); //strip all non-numerics
+                $london_weighting_allowance = preg_replace("/[^0-9]/", "", $london_weighting_allowance); //strip all non-numerics
             }
             if (isset($london_weighting_allowance) && is_numeric($london_weighting_allowance)) {
-                update_field('salary_london', $london_weighting_allowance, $post_id);
+                update_field('salary_london', intval($london_weighting_allowance), $post_id);
             } else {
                 update_field('salary_london', '', $post_id);
             }

--- a/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
+++ b/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
@@ -234,7 +234,7 @@ function set_job_details($job_content, $totalspans, $post_id)
             if (isset($london_weighting_allowance) && is_numeric($london_weighting_allowance)) {
                 update_field('salary_london', $london_weighting_allowance, $post_id);
             } else {
-                update_field('salary_london', 1234, $post_id);
+                update_field('salary_london', '', $post_id);
             }
             
         }

--- a/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
+++ b/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
@@ -225,7 +225,18 @@ function set_job_details($job_content, $totalspans, $post_id)
             if (is_numeric($salary_max)) {
                 update_field('salary_max', $salary_max, $post_id);
             }
-
+            if (preg_match("plus a London weighting allowance of", $salary)) { //London weighting string identified
+                $london_weighting_allowance = explode("plus a London weighting allowance of ", $salary)[1]; //split by start of the agreed term - take second element
+                $london_weighting_allowance = explode(" per annum", $london_weighting_allowance)[0]; //split by end of the agreed term - take first element
+                $london_weighting_allowance = str_replace(".00", "", $london_weighting_allowance); //strip occasional use of .00 (e.g. £3,889.00)
+                $london_weighting_allowance = preg_replace("/[^0-9]/", "", $london_array[1]); //strip all non-numerics
+            }
+            if (isset($london_weighting_allowance) && is_numeric($london_weighting_allowance)) {
+                update_field('salary_london', $london_weighting_allowance, $post_id);
+            } else {
+                update_field('salary_london', 1234, $post_id);
+            }
+            
         }
 
         // Save Working Pattern Info

--- a/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
+++ b/web/app/themes/justicejobs/inc/jobs-handler/add-edit-jobs.php
@@ -225,10 +225,10 @@ function set_job_details($job_content, $totalspans, $post_id)
             if (is_numeric($salary_max)) {
                 update_field('salary_max', $salary_max, $post_id);
             }
-            if (preg_match("/London .* allowance of \£.* per annum/", $salary)) { //London weighting string identified
-                $london_weighting_allowance = preg_replace("/London .* allowance of \£/","|||",$salary); //replace the regex string with a constant for splitting
+            if (preg_match("/( .* London .* allowance of \£.*)/i", $salary)) { //London weighting string identified
+                $london_weighting_allowance = preg_replace("/London .* allowance of \£/i","|||",$salary); //replace the regex string with a constant for splitting
                 $london_weighting_allowance = explode("|||", $london_weighting_allowance)[1]; //split by start of the agreed term - take second element
-                $london_weighting_allowance = explode(" per annum", $london_weighting_allowance)[0]; //split by end of the agreed term - take first element
+                $london_weighting_allowance = explode(")", $london_weighting_allowance)[0]; //split by end of the agreed term - take first element
                 $london_weighting_allowance = str_replace(".00", "", $london_weighting_allowance); //strip occasional use of .00 (e.g. £3,889.00)
                 $london_weighting_allowance = preg_replace("/[^0-9]/", "", $london_weighting_allowance); //strip all non-numerics
             }

--- a/web/app/themes/justicejobs/search-apply-page.php
+++ b/web/app/themes/justicejobs/search-apply-page.php
@@ -226,18 +226,18 @@ Template Name: Search/Apply Template
                                     $salary_min = get_field('salary_min');
 
                                     if(!empty($salary_min)){
-                                        echo '&#163;' . number_format($salary_min);
+                                        echo '&pound;' . number_format($salary_min);
 
                                         $salary_max = get_field('salary_max');
 
                                         if(!empty($salary_max)){
 
-                                            echo ' - &#163;' . number_format($salary_max);
+                                            echo ' - &pound;' . number_format($salary_max);
 
                                         }
                                         $london_allowance = number_format(intval(get_field('salary_london')));
                                         if (!empty($london_allowance)) {
-                                            echo "<br /> + &#163;$london_allowance LWA";
+                                            echo "<br /> + &pound;$london_allowance LWA";
                                         }
                                     }
                                     ?>

--- a/web/app/themes/justicejobs/search-apply-page.php
+++ b/web/app/themes/justicejobs/search-apply-page.php
@@ -223,19 +223,23 @@ Template Name: Search/Apply Template
                             <td>
                                 <p>
                                     <?php
-                                    $salary_min = get_field(('salary_min'));
+                                    $salary_min = get_field('salary_min');
 
                                     if(!empty($salary_min)){
                                         echo '&#163;' . number_format($salary_min);
 
-                                        $salary_max = get_field(('salary_max'));
+                                        $salary_max = get_field('salary_max');
 
                                         if(!empty($salary_max)){
 
                                             echo ' - &#163;' . number_format($salary_max);
 
                                         }
-
+                                        $london_allowance = number_format(get_field('salary_london'));
+                                        
+                                        if (!empty($london_allowance)) {
+                                            echo "plus &#163;$london_allowance LWA";
+                                        }
                                     }
                                     ?>
                                 </p>

--- a/web/app/themes/justicejobs/search-apply-page.php
+++ b/web/app/themes/justicejobs/search-apply-page.php
@@ -235,10 +235,9 @@ Template Name: Search/Apply Template
                                             echo ' - &#163;' . number_format($salary_max);
 
                                         }
-                                        $london_allowance = number_format(get_field('salary_london'));
-                                        
+                                        $london_allowance = number_format(intval(get_field('salary_london')));
                                         if (!empty($london_allowance)) {
-                                            echo "plus &#163;$london_allowance LWA";
+                                            echo "<br /> + &#163;$london_allowance LWA";
                                         }
                                     }
                                     ?>

--- a/web/app/themes/justicejobs/search.php
+++ b/web/app/themes/justicejobs/search.php
@@ -475,7 +475,10 @@ if ($_location && empty($_locations_relevant)) {
                                             echo ' - &#163;' . number_format($salary_max);
 
                                         }
-
+                                        $london_allowance = number_format(get_field('salary_london'));
+                                        if (!empty($london_allowance)) {
+                                            echo "<br /> + &#163;$london_allowance LWA";
+                                        }
                                     }
                                     ?>
                                 </p>

--- a/web/app/themes/justicejobs/search.php
+++ b/web/app/themes/justicejobs/search.php
@@ -463,19 +463,19 @@ if ($_location && empty($_locations_relevant)) {
                             <td>
                                 <p>
                                     <?php
-                                    $salary_min = get_field(('salary_min'));
+                                    $salary_min = get_field('salary_min');
 
                                     if(!empty($salary_min)){
                                         echo '&#163;' . number_format($salary_min);
 
-                                        $salary_max = get_field(('salary_max'));
+                                        $salary_max = get_field('salary_max');
 
                                         if(!empty($salary_max)){
 
                                             echo ' - &#163;' . number_format($salary_max);
 
                                         }
-                                        $london_allowance = number_format(get_field('salary_london'));
+                                        $london_allowance = number_format(intval(get_field('salary_london')));
                                         if (!empty($london_allowance)) {
                                             echo "<br /> + &#163;$london_allowance LWA";
                                         }

--- a/web/app/themes/justicejobs/search.php
+++ b/web/app/themes/justicejobs/search.php
@@ -466,18 +466,18 @@ if ($_location && empty($_locations_relevant)) {
                                     $salary_min = get_field('salary_min');
 
                                     if(!empty($salary_min)){
-                                        echo '&#163;' . number_format($salary_min);
+                                        echo '&pound;' . number_format($salary_min);
 
                                         $salary_max = get_field('salary_max');
 
                                         if(!empty($salary_max)){
 
-                                            echo ' - &#163;' . number_format($salary_max);
+                                            echo ' - &pound;' . number_format($salary_max);
 
                                         }
                                         $london_allowance = number_format(intval(get_field('salary_london')));
                                         if (!empty($london_allowance)) {
-                                            echo "<br /> + &#163;$london_allowance LWA";
+                                            echo "<br /> + &pound;$london_allowance London weighting";
                                         }
                                     }
                                     ?>

--- a/web/app/themes/justicejobs/single-agency.php
+++ b/web/app/themes/justicejobs/single-agency.php
@@ -58,7 +58,7 @@ Template Post Type: agency
                     <?php
                         //Hard coding in HMPPS subordinate agencies to mimic heirarchy
 
-                        $HMPPS_underlings = ["HM Prison Service","HM Probation Service"];
+                        $HMPPS_underlings = ["HM Prison Service","HM Probation Service","Specialist Production Instructors"];
 
                         if (in_array(strip_tags(get_the_title()), $HMPPS_underlings)) {
                             $HMPPS_found = false;

--- a/web/app/themes/justicejobs/single-job.php
+++ b/web/app/themes/justicejobs/single-job.php
@@ -73,7 +73,7 @@
                         echo ' &ndash; &pound;' . number_format($salary_max);
                     }
                     if (!empty($london_allowance)) {
-                        echo " + London weighting of &pound;" . number_format($london_allowance);
+                        echo " + London weighting allowance of &pound;" . number_format($london_allowance);
                     }
                 }
 

--- a/web/app/themes/justicejobs/single-job.php
+++ b/web/app/themes/justicejobs/single-job.php
@@ -62,13 +62,6 @@
                     $salary_max = get_field(('salary_max'));
                     $london_allowance = intval(get_field(('salary_london')));
 
-                /*    if (!empty($london_allowance)) {
-                        if(!empty($salary_max)){
-                            $salary_max = $salary_max + $london_allowance;
-                        } else {
-                            $salary_max = $salary_min + $london_allowance;
-                        }
-                    }*/
                     if(!empty($salary_max)){
                         echo ' &ndash; &pound;' . number_format($salary_max);
                     }

--- a/web/app/themes/justicejobs/single-job.php
+++ b/web/app/themes/justicejobs/single-job.php
@@ -99,6 +99,14 @@
                             <?php echo $salary; ?>
                         </span>
                     </p>
+                    <?php 
+                    $london_allowance = get_field(('salary_london'));
+                    if (!empty($london_allowance)) {
+                    ?>
+                    <p>
+                        Plus a London weighting allowance of £<?php echo number_format($london_allowance); ?> per annum.
+                    </p>
+                    <?php } ?>
                     <?php } ?>
                     <h2>Additional Information</h2>
                     <?php the_field('additional_information'); ?>

--- a/web/app/themes/justicejobs/single-job.php
+++ b/web/app/themes/justicejobs/single-job.php
@@ -60,13 +60,21 @@
                     echo '&pound;' . number_format($salary_min);
 
                     $salary_max = get_field(('salary_max'));
+                    $london_allowance = intval(get_field(('salary_london')));
 
+                /*    if (!empty($london_allowance)) {
+                        if(!empty($salary_max)){
+                            $salary_max = $salary_max + $london_allowance;
+                        } else {
+                            $salary_max = $salary_min + $london_allowance;
+                        }
+                    }*/
                     if(!empty($salary_max)){
-
                         echo ' &ndash; &pound;' . number_format($salary_max);
-
                     }
-
+                    if (!empty($london_allowance)) {
+                        echo " + London weighting of &pound;" . number_format($london_allowance);
+                    }
                 }
 
                 $aria_label = strstr($post->post_title, ' -', true);
@@ -99,14 +107,6 @@
                             <?php echo $salary; ?>
                         </span>
                     </p>
-                    <?php 
-                    $london_allowance = get_field(('salary_london'));
-                    if (!empty($london_allowance)) {
-                    ?>
-                    <p>
-                        Plus a London weighting allowance of £<?php echo number_format($london_allowance); ?> per annum.
-                    </p>
-                    <?php } ?>
                     <?php } ?>
                     <h2>Additional Information</h2>
                     <?php the_field('additional_information'); ?>

--- a/web/app/themes/justicejobs/src/scss/base/_typography.scss
+++ b/web/app/themes/justicejobs/src/scss/base/_typography.scss
@@ -100,3 +100,7 @@ button {
         font-size: 3.6rem;
     }
 }
+
+u {
+    text-decoration: none;
+}


### PR DESCRIPTION
Added London Weighting Allowance stuff
- Code to extract the allowance figure from pre-agreed text
  - Text is `(plus a London Weighting Allowance of £3,998)`
  - Will work if brackets are there and London ... allowance is followed by a number (regex)
- Minor fixes to HMPPS back links and unwanted underlining.